### PR TITLE
Fixes for FillArrays 0.4.0

### DIFF
--- a/src/infarrays.jl
+++ b/src/infarrays.jl
@@ -75,7 +75,7 @@ for typ in (:Ones, :Zeros, :Fill)
     end
 end
 
-BroadcastStyle(::Type{Eye{T,OneToInf{I}}}) where {T,I} = LazyArrayStyle{2}()
+BroadcastStyle(::Type{<:Eye{T,OneToInf{I}}}) where {T,I} = LazyArrayStyle{2}()
 
 #####
 # Diagonal

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -304,7 +304,8 @@ end
     end
 
     @testset "show" begin
-        @test summary(1:∞) == "InfUnitRange{Int64} with indices OneToInf()"
+        # NOTE: Interpolating Int to ensure it's displayed properly across 32- and 64-bit
+        @test summary(1:∞) == "InfUnitRange{$Int} with indices OneToInf()"
         @test Base.inds2string(axes(1:∞)) == "OneToInf()"
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -408,9 +408,12 @@ end
 @testset "Taylor ODE" begin
     e₁ = Vcat(1, Zeros(∞))
     D = Hcat(Zeros(∞), Diagonal(1:∞))
-    @test typeof(Eye(∞)) == Eye{Float64,OneToInf{Int}}
-    @test Base.BroadcastStyle(typeof(Eye(∞))) == LazyArrays.LazyArrayStyle{2}()
-    L = Vcat(e₁', Eye(∞) + D)
+    I_inf = Eye(∞)
+    @test I_inf isa Eye{Float64,OneToInf{Int}}
+    @test axes(I_inf) == (OneToInf{Int}(), OneToInf{Int}())
+    @test eltype(I_inf) == Float64
+    @test Base.BroadcastStyle(typeof(I_inf)) == LazyArrays.LazyArrayStyle{2}()
+    L = Vcat(e₁', I_inf + D)
     @test L[1:3,1:3] == [1.0 0.0 0.0;
                          1.0 1.0 0.0;
                          0.0 1.0 2.0]


### PR DESCRIPTION
`Eye` is now a `Union`, so we need to adjust the tests and definitions slightly. This should be completely backwards compatible with earlier versions of FillArrays. I've verified that tests pass with the current master version of FillArrays, which is what will be v0.4.0 in https://github.com/JuliaLang/METADATA.jl/pull/20199.